### PR TITLE
feat: add stamping and tagging of images

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,8 @@ import %workspace%/.aspect/bazelrc/bazel6.bazelrc
 
 ### YOUR PROJECT SPECIFIC SETTINGS GO HERE ###
 
+build --stamp --workspace_status_command=$PWD/tools/workspace_status.sh
+
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This
 # should be last statement in this config so the user configuration is able to overwrite flags from

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -86,8 +86,7 @@ oci_image(
     os = "linux",
     # This needs to be done with stamping etc, later
     labels = {
-        "image.version": "xxx",
-        "image.source": "https://github.com/WASSHAInc/something",
+        "org.opencontainers.image.version": """($stamp.STABLE_BUILD_VERSION // "MISSING")""",
     },
     visibility = ["//visibility:public"],
 )
@@ -107,8 +106,7 @@ oci_image(
     os = "linux",
     # This needs to be done with stamping etc, later
     labels = {
-        "image.version": "xxx",
-        "image.source": "https://github.com/WASSHAInc/something",
+        "org.opencontainers.image.version": """($stamp.STABLE_BUILD_VERSION // "MISSING")""",
     },
     visibility = ["//visibility:public"],
 )
@@ -159,10 +157,11 @@ oci_image_index(
 stamp_tags(
     name = "stamped",
     repotags = [
-        # With --stamp, use the --embed_label value, otherwise use 0.0.0
-        """($stamp.BUILD_EMBED_LABEL // "0.0.0")""",
+        """($stamp.STABLE_BUILD_VERSION // "MISSING")""",
+        """($stamp.STABLE_GIT_COMMIT // "MISSING")""",
+        """($stamp.STABLE_USER_NAME // "MISSING")""",
         "latest",
-    ],
+    ]
 )
 
 # Push all images
@@ -178,4 +177,13 @@ oci_push(
     name = "push_image_amd64",
     image = ":image_amd64",
     repository = "067333984569.dkr.ecr.af-south-1.amazonaws.com/example",
+    repotags = ":stamped",
+)
+
+# Push only amd64
+oci_push(
+    name = "push_image_arm64",
+    image = ":image_arm64",
+    repository = "067333984569.dkr.ecr.af-south-1.amazonaws.com/example",
+    repotags = ":stamped",
 )

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Install `bazelisk`, that should be all that is needed.
 ## Commands
 
 Push images to ECR:
- `bazelisk run //:push_image_index --stamp --embed_label=0.0.1`
+ `bazelisk run //:push_image_index`
+
+The above will push both amd64 and arm64 images. When pulling an image there is not need to specify architecture.
 
 Run locally:
  `bazelisk run //:bin`
@@ -29,6 +31,14 @@ Build a docker image tarball for your platform:
 
 Load tarball into local docker:
  `docker load -i bazel-bin/tarball/tarball_YOURPLATFORM.tar`
+
+Authenticate docker:  
+
+```
+aws-vault exec wassha-eaas-dev -- aws ecr get-login-password --region af-south-1 | docker login --username AWS --password-stdin 067333984569.dkr.ecr.af-south-1.amazonaws.com
+```
+
+This should be replaced with an authentication helper.
 
 # Aspect Bazel Automatic Updates
 

--- a/tools/workspace_status.sh
+++ b/tools/workspace_status.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# See https://bazel.build/docs/user-manual#workspace-status
+
+TAG=`git describe --long 2> /dev/null | sed -e 's/^v//;s/-/./;s/-g/+/'`
+LOCAL_CHANGES=`git status --untracked-files=no --porcelain`
+
+# Starts with the STABLE_ prefix so that Bazel will always rebuild stamped outputs if the git tag changes.
+echo "STABLE_BUILD_VERSION ${TAG:-NONE}$(if [[ $LOCAL_CHANGES == "" ]]; then echo ''; else echo '.with-local-changes'; fi)"
+echo "STABLE_GIT_COMMIT $(git rev-parse HEAD)"
+echo "STABLE_USER_NAME $USER"
+echo "BUILD_SCM_USER $(git config user.email)"
+echo "BUILD_SCM_BRANCH $(git symbolic-ref --short HEAD)"
+echo "BUILD_CURRENT_TIME $(date +%s)"
+echo "BUILD_RANDOM_HASH $(cat /proc/sys/kernel/random/uuid)"

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-# See https://bazel.build/docs/user-manual#workspace-status
-
-# Starts with the STABLE_ prefix so that Bazel will always rebuild stamped outputs if the git tag changes.
-echo STABLE_BUILD_VERSION "$(git describe --long | sed -e 's/^v//;s/-/./;s/-g/+/')"


### PR DESCRIPTION
This commit enables basic git backed, workspace status.

Workspace status is also used for tagging of images.

We use the `.bazelrc` file to automate stamping when executing `bazel run`.